### PR TITLE
Upgrade nginx to 1.26.1 for Fedora 40

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-rpms
+rpms/*.rpm

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:39
+FROM fedora:40
 
 RUN dnf install rpm-build dnf-utils tree -y
 

--- a/Containerfile.debug
+++ b/Containerfile.debug
@@ -1,3 +1,3 @@
-FROM fedora:39
+FROM fedora:40
 
 RUN dnf install rpm-build dnf-utils tree -y

--- a/nginx.spec
+++ b/nginx.spec
@@ -9,7 +9,7 @@
 %global lua_resty_core_version 0.1.28
 %global lua_resty_lrucache_version 0.13
 %global ngx_devel_kit_version 0.3.3
-%global luajit2_version 2.1-20240314
+%global luajit2_version 2.1-20240626
 %global ngx_http_redis_version 0.4.1-cmm
 %global headers_more_version 0.37
 %global modsecurity_nginx_version 1.0.3
@@ -19,7 +19,7 @@
 
 Name: nginx-lua-waf
 Summary: High performance web server nginx with lua and modsecurity plugins
-Version: 1.25.4
+Version: 1.26.1
 Release: 1%{?dist}
 Conflicts: nginx nginx-mimetypes nginx-core luajit
 
@@ -75,6 +75,7 @@ cp -r %{buildroot}/../luajit/* /
 export LUAJIT_LIB=/usr/lib
 export LUAJIT_INC=/usr/include/luajit-2.1
 export DESTDIR=%{buildroot}
+export CFLAGS="-std=gnu89"
 nginx_ldopts="$RPM_LD_FLAGS -Wl,-E"
 ./configure \
     --prefix=%{_datadir}/nginx \


### PR DESCRIPTION
Related [#5303](https://github.com/surfly/it/issues/5303)