### PR TITLE
Update nginx dependencies

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:41
+FROM fedora:42
 
 RUN dnf install rpm-build dnf-utils tree -y
 

--- a/Containerfile.debug
+++ b/Containerfile.debug
@@ -1,3 +1,3 @@
-FROM fedora:41
+FROM fedora:42
 
 RUN dnf install rpm-build dnf-utils tree -y

--- a/nginx.spec
+++ b/nginx.spec
@@ -5,21 +5,21 @@
 %global nginx_srcdir %{_usrsrc}/%{name}-%{version}-%{release}
 %global lua_lib /usr/lib
 %global lua_local_lib /usr/local/lib/lua
-%global lua_nginx_module_version 0.10.27
-%global lua_resty_core_version 0.1.30
+%global lua_nginx_module_version 0.10.28
+%global lua_resty_core_version 0.1.31
 %global lua_resty_lrucache_version 0.15
 %global ngx_devel_kit_version 0.3.3
-%global luajit2_version 2.1-20241113
+%global luajit2_version 2.1-20250529
 %global ngx_http_redis_version 0.4.1-cmm
-%global headers_more_version 0.37
-%global modsecurity_nginx_version 1.0.3
+%global headers_more_version 0.39
+%global modsecurity_nginx_version 1.0.4
 
 # By default downloading of sources is disabled
 %undefine _disable_source_fetch
 
 Name: nginx-lua-waf
 Summary: High performance web server nginx with lua and modsecurity plugins
-Version: 1.27.4
+Version: 1.29.0
 Release: 1%{?dist}
 Conflicts: nginx nginx-mimetypes nginx-core luajit
 


### PR DESCRIPTION
Bump Fedora base image from 41 to 42 in Containerfile and Containerfile.debug. Update nginx.spec to newer versions of nginx, Lua modules, luajit2, headers_more, and modsecurity_nginx.

Realted to https://github.com/surfly/it/issues/6612