### PR TITLE
Update to Fedora 44, nginx 1.31.2 and latest modules

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:43
+FROM fedora:44
 
 RUN dnf install rpm-build dnf-utils tree -y
 

--- a/nginx.spec
+++ b/nginx.spec
@@ -5,13 +5,13 @@
 %global nginx_srcdir %{_usrsrc}/%{name}-%{version}-%{release}
 %global lua_lib /usr/lib
 %global lua_local_lib /usr/local/lib/lua
-%global lua_nginx_module_version 0.10.29
+%global lua_nginx_module_version 0.10.31
 %global lua_resty_core_version 0.1.32
 %global lua_resty_lrucache_version 0.15
 %global ngx_devel_kit_version 0.3.4
-%global luajit2_version 2.1-20260311
+%global luajit2_version 2.1-20260701
 %global ngx_http_redis_version 0.4.1-cmm
-%global headers_more_version 0.39
+%global headers_more_version 0.40
 %global modsecurity_nginx_version 1.0.4
 
 # By default downloading of sources is disabled
@@ -19,7 +19,7 @@
 
 Name: nginx-lua-waf
 Summary: High performance web server nginx with lua and modsecurity plugins
-Version: 1.29.8
+Version: 1.31.2
 Release: 1%{?dist}
 Conflicts: nginx nginx-mimetypes nginx-core luajit
 


### PR DESCRIPTION
Related https://github.com/surfly/it/issues/7959

Quarterly dependency upgrade of the `nginx-lua-waf` RPM. Bumps the build to Fedora 44 and nginx 1.29.8 → 1.31.2 (staying on the mainline track), plus the modules that had new non-rc releases: lua-nginx-module 0.10.29 → 0.10.31, luajit2 2.1-20260311 → 2.1-20260701, headers-more 0.39 → 0.40. The rest (ngx_devel_kit 0.3.4, lua-resty-core 0.1.32, lua-resty-lrucache 0.15, ngx_http_redis 0.4.1-cmm, ModSecurity-nginx 1.0.4) are already at their latest non-rc versions; libmodsecurity comes from the Fedora repo so it moves with the base image.

Built and validated on sixnine: `nginx-lua-waf-1.31.2-1.fc44.x86_64.rpm` installs cleanly in a Fedora 44 container and `nginx -V` reports nginx/1.31.2 with every module compiled in, linked against Fedora 44's `libmodsecurity.so.3`. Once merged I'll cut the `1.31.2-1` GitHub release and point cobro's `src/nginx` at it (Fedora 44 + new RPM + CRS 4.28.0), with the WAF test suites.
