### PR TITLE
Revert lua-nginx-module to 0.10.29 (pair with lua-resty-core 0.1.32)

### DIFF
--- a/nginx.spec
+++ b/nginx.spec
@@ -5,7 +5,7 @@
 %global nginx_srcdir %{_usrsrc}/%{name}-%{version}-%{release}
 %global lua_lib /usr/lib
 %global lua_local_lib /usr/local/lib/lua
-%global lua_nginx_module_version 0.10.31
+%global lua_nginx_module_version 0.10.29
 %global lua_resty_core_version 0.1.32
 %global lua_resty_lrucache_version 0.15
 %global ngx_devel_kit_version 0.3.4
@@ -20,7 +20,7 @@
 Name: nginx-lua-waf
 Summary: High performance web server nginx with lua and modsecurity plugins
 Version: 1.31.2
-Release: 1%{?dist}
+Release: 2%{?dist}
 Conflicts: nginx nginx-mimetypes nginx-core luajit
 
 Source0: https://nginx.org/download/nginx-%{version}.tar.gz


### PR DESCRIPTION
Related https://github.com/surfly/it/issues/7959

Fix for the `1.31.2-1` build: nginx wouldn't start in the full stack because `resty.core` failed to load at init — `lua-nginx-module` 0.10.31 was mismatched with `lua-resty-core` 0.1.32. They're a coupled pair, and 0.10.31 needs resty-core ≥ 0.1.33, which is **rc-only** (we exclude rc's). So bumping `lua-nginx-module` alone was wrong.

Reverts `lua-nginx-module` to **0.10.29** (the stable pair for resty-core 0.1.32) and bumps `Release` to **2**. The other bumps (nginx 1.31.2, luajit2 2.1-20260701, headers-more 0.40) are unaffected and kept.

Validated on sixnine: rebuilt RPM installs on Fedora 44, `nginx -V` shows lua-nginx-module 0.10.29, and `nginx -t` with `init_by_lua_block { require "resty.core" }` passes — resty.core loads, which is what failed before (the WAF unit suites use a minimal config and don't exercise resty.core, so they missed it; the cobro integration suites caught it).
