### PR TITLE
arm64: build.sh copies RPMs from the arch-specific rpmbuild output dir

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,4 +12,4 @@ podman run \
     --rm \
     -v $PWD/rpms/:/rpms:Z \
     localhost/nginx-build-image:latest \
-    bash -c "rpmbuild -bb /root/rpmbuild/SPECS/nginx.spec && cp /root/rpmbuild/RPMS/x86_64/* /rpms/"
+    bash -c "rpmbuild -bb /root/rpmbuild/SPECS/nginx.spec && cp /root/rpmbuild/RPMS/\$(uname -m)/* /rpms/"


### PR DESCRIPTION
Related https://github.com/surfly/it/issues/7856

`build.sh` ended with `cp /root/rpmbuild/RPMS/x86_64/* /rpms/`, hardcoding the arch. On aarch64 `rpmbuild` outputs to `RPMS/aarch64/` and the copy failed even though the spec itself has no `BuildArch` and builds fine cross-arch.

Verified in a native aarch64 AlmaLinux 10 VM: this produces `nginx-lua-waf-1.31.2-2.fc44.aarch64.rpm`, and `nginx -V` / `nginx -t` confirm all five bundled modules match the released x86_64 build and resty.core loads correctly.

Not releasing the aarch64 RPM as part of this PR — that's a separate call on the existing `1.31.2-2` tag.