### PR TITLE
Add njs dynamic module

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@ nginx-lua-waf
 
 ## Description
 This is a build of nginx which supports lua and modesecurity plugin. It is intended
-to be used as a reverse proxy with caching and WAF capabilities behind a load balancer
-(it is currently built without SSL support).
+to be used as a reverse proxy with caching and WAF capabilities behind a load balancer.
+It is built with `--with-http_ssl_module` so `proxy_ssl_*` directives work when acting
+as an SSL client to an upstream (e.g. `xresproxy` fetching external HTTPS resources);
+it does not terminate client-facing TLS itself, and ships no `http_v2`/`http_v3` modules
+since nothing in our nginx configs uses them.
 
 Features:
  - [luajit 2.1 from openresty](https://github.com/openresty/luajit2) is bundled with the build

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Features:
  - [ngx_http_redis module](https://github.com/centminmod/ngx_http_redis/) - caching responses in Redis
  - [headers-more-nginx-module](https://github.com/openresty/headers-more-nginx-module) - for setting headers
  - [ModSecurity](https://github.com/owasp-modsecurity/ModSecurity-nginx) - waf capabilities
+ - [njs](https://github.com/nginx/njs) - JavaScript scripting (ngx_http_js_module / ngx_stream_js_module), built as dynamic modules loaded via an absolute `load_module` path (see `mod-stream.conf` for the existing convention)
 
 ## Build instructions
 Running `./build.sh` will output a new RPM file in the `rpms/` directory.

--- a/nginx.spec
+++ b/nginx.spec
@@ -105,6 +105,7 @@ nginx_ldopts="$RPM_LD_FLAGS -Wl,-E"
     --with-http_realip_module \
     --with-http_secure_link_module \
     --with-http_slice_module \
+    --with-http_ssl_module \
     --with-http_stub_status_module \
     --with-http_sub_module \
     --with-pcre \

--- a/nginx.spec
+++ b/nginx.spec
@@ -13,14 +13,15 @@
 %global ngx_http_redis_version 0.4.1-cmm
 %global headers_more_version 0.40
 %global modsecurity_nginx_version 1.0.4
+%global njs_version 1.0.0
 
 # By default downloading of sources is disabled
 %undefine _disable_source_fetch
 
 Name: nginx-lua-waf
-Summary: High performance web server nginx with lua and modsecurity plugins
+Summary: High performance web server nginx with lua, modsecurity and njs plugins
 Version: 1.31.2
-Release: 2%{?dist}
+Release: 3%{?dist}
 Conflicts: nginx nginx-mimetypes nginx-core luajit
 
 Source0: https://nginx.org/download/nginx-%{version}.tar.gz
@@ -35,11 +36,12 @@ Source104: https://github.com/openresty/lua-resty-lrucache/archive/refs/tags/v%{
 Source105: https://github.com/centminmod/ngx_http_redis/archive/refs/tags/%{ngx_http_redis_version}.tar.gz
 Source106: https://github.com/openresty/headers-more-nginx-module/archive/refs/tags/v%{headers_more_version}.tar.gz
 Source107: https://github.com/owasp-modsecurity/ModSecurity-nginx/archive/refs/tags/v%{modsecurity_nginx_version}.tar.gz
+Source108: https://github.com/nginx/njs/archive/refs/tags/%{njs_version}.tar.gz
 
 License: BSD
 Group: System Environment/Daemons
 URL: http://nginx.org
-BuildRequires: pcre2-devel zlib-devel make gcc systemd libmodsecurity-devel
+BuildRequires: pcre2-devel zlib-devel make gcc systemd libmodsecurity-devel openssl-devel libxml2-devel libxslt-devel
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 %description
@@ -66,6 +68,8 @@ tar -xzvf %{SOURCE106} -C %{_builddir}
 %global SOURCE106 %{_builddir}/headers-more-nginx-module-%{headers_more_version}
 tar -xzvf %{SOURCE107} -C %{_builddir}
 %global SOURCE107 %{_builddir}/ModSecurity-nginx-%{modsecurity_nginx_version}
+tar -xzvf %{SOURCE108} -C %{_builddir}
+%global SOURCE108 %{_builddir}/njs-%{njs_version}
 
 # Build luajit
 cd %{SOURCE101} && make && make install PREFIX=/usr DESTDIR=%{buildroot}/../luajit
@@ -114,7 +118,8 @@ nginx_ldopts="$RPM_LD_FLAGS -Wl,-E"
     --add-module=%{SOURCE102} \
     --add-module=%{SOURCE105} \
     --add-module=%{SOURCE106} \
-    --add-module=%{SOURCE107}
+    --add-module=%{SOURCE107} \
+    --add-dynamic-module=%{SOURCE108}/nginx
 
 %make_build
 
@@ -188,6 +193,8 @@ rm -rf %{buildroot}/../luajit
 %dir %{nginx_moduleconfdir}
 %{nginx_moduleconfdir}/mod-stream.conf
 %{nginx_moduledir}/ngx_stream_module.so
+%{nginx_moduledir}/ngx_http_js_module.so
+%{nginx_moduledir}/ngx_stream_js_module.so
 %dir %{_datadir}/nginx
 %dir %{_datadir}/nginx/html
 %dir %{_sysconfdir}/nginx


### PR DESCRIPTION
Related https://github.com/surfly/it/issues/8162

xresproxy's `js_*` directives currently only come from nginx.org's prebuilt `nginx.org/packages/centos/10` channel, which has raised its CPU baseline to x86-64-v3 and breaks on a customer's older/VM hardware. Building njs (`ngx_http_js_module` + `ngx_stream_js_module`) into this spec the same way as the other modules removes that dependency, since everything here compiles with Fedora's default `-march=x86-64` baseline.

Needed three new BuildRequires (`openssl-devel`, `libxml2-devel`, `libxslt-devel`) for njs's crypto/webcrypto/xslt submodules — confirmed via a real build on sixnine that the RPM installs and `nginx -t` loads the module cleanly. Note the modules install under `--modules-path` (`/usr/lib64/nginx/modules`), not under `--prefix`, so consumers need an absolute `load_module` path — same convention `mod-stream.conf` already uses for `ngx_stream_module.so`.

Bumped Release to 3. Once merged, a new RPM needs building and uploading via `grm release` per the README before cobro can switch xresproxy over to it (surfly/cobro PR to follow).