### PR TITLE
Build and validate RPMs for x86_64 and aarch64 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,78 @@
+name: Build
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    tags: ['*']
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    name: Build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install podman
+        run: command -v podman || { sudo apt-get update && sudo apt-get install -y podman; }
+
+      - name: Build the RPM
+        run: ./build.sh
+
+      - name: Check the RPM is ${{ matrix.arch }}
+        run: |
+          ls -l rpms/
+          ls rpms/*.${{ matrix.arch }}.rpm > /dev/null
+
+      - name: Validate the RPM
+        run: ./validate.sh
+
+      - name: Upload the RPM
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpm-${{ matrix.arch }}
+          path: rpms/*.rpm
+          if-no-files-found: error
+
+  release:
+    name: Attach RPMs to the release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download the RPMs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: rpm-*
+          merge-multiple: true
+          path: rpms
+
+      - name: Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1 \
+            || gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --notes ""
+          gh release upload "$TAG" rpms/*.rpm --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
         run: |
-          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1 \
-            || gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --notes ""
+          # Tolerate an existing release; the upload below fails loudly if there
+          # is genuinely nothing to attach to.
+          gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --notes "" || true
           gh release upload "$TAG" rpms/*.rpm --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,16 @@ jobs:
       - name: Install podman
         run: command -v podman || { sudo apt-get update && sudo apt-get install -y podman; }
 
+      - name: Check the tag matches nginx.spec
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          release=$(grep -m1 '^Release:' nginx.spec | awk '{print $2}')
+          expected="$(grep -m1 '^Version:' nginx.spec | awk '{print $2}')-${release%%\%*}"
+          if [[ "$GITHUB_REF_NAME" != "$expected" ]]; then
+            echo "tag $GITHUB_REF_NAME does not match nginx.spec ($expected)" >&2
+            exit 1
+          fi
+
       - name: Build the RPM
         run: ./build.sh
 
@@ -43,7 +53,7 @@ jobs:
           ls rpms/*.${{ matrix.arch }}.rpm > /dev/null
 
       - name: Validate the RPM
-        run: ./validate.sh
+        run: ./validate.sh rpms/*.${{ matrix.arch }}.rpm
 
       - name: Upload the RPM
         uses: actions/upload-artifact@v4

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:44
+FROM quay.io/fedora/fedora:44
 
 RUN dnf install rpm-build dnf-utils tree -y
 

--- a/Containerfile.debug
+++ b/Containerfile.debug
@@ -1,3 +1,3 @@
-FROM fedora:42
+FROM quay.io/fedora/fedora:44
 
 RUN dnf install rpm-build dnf-utils tree -y

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ Features:
 
 ## Build instructions
 Running `./build.sh` will output a new RPM file in the `rpms/` directory, and
-`./validate.sh` checks it: every module is present at the version `nginx.spec`
-pins, and `resty.core` loads (a mismatched lua-nginx-module / lua-resty-core pair
-passes cobro's WAF unit tests but kills nginx in the prod config).
+`./validate.sh` checks it: it was built from the current spec, every module
+compiled into it matches the pinned version, and all five shipped modules load —
+including `resty.core`, where a mismatched lua-nginx-module / lua-resty-core pair
+passes cobro's WAF unit tests but kills nginx in the prod config.
 
 CI does both for `x86_64` and `aarch64` on every pull request, so a local build is
 only needed to iterate on the spec. The build needs a host of the target
@@ -42,12 +43,14 @@ internal public storage.
   of permissions issues.
 
 ### Upload a new RPM to github releases:
-Push a tag named `<Version>-<Release>` (matching `nginx.spec`) and CI builds both
-architectures, validates them, and attaches them to that release — creating it if
-it does not exist yet:
+Bump `Release:` (or `Version:`) in `nginx.spec` first — a release tag has to be a
+new one, and CI rejects a tag that does not match the spec. Then push a tag named
+`<Version>-<Release>` and CI builds both architectures, validates them, and
+attaches them to that release, creating it if it does not exist yet:
 
 ```bash
-git tag 1.31.2-4 && git push origin 1.31.2-4
+# with nginx.spec at Version: 1.31.2 / Release: 5%{?dist}
+git tag 1.31.2-5 && git push origin 1.31.2-5
 ```
 
 To attach an RPM by hand instead — a rebuild of an already-released tag, or an

--- a/README.md
+++ b/README.md
@@ -19,7 +19,14 @@ Features:
  - [njs](https://github.com/nginx/njs) - JavaScript scripting (ngx_http_js_module / ngx_stream_js_module), built as dynamic modules loaded via an absolute `load_module` path (see `mod-stream.conf` for the existing convention)
 
 ## Build instructions
-Running `./build.sh` will output a new RPM file in the `rpms/` directory.
+Running `./build.sh` will output a new RPM file in the `rpms/` directory, and
+`./validate.sh` checks it: every module is present at the version `nginx.spec`
+pins, and `resty.core` loads (a mismatched lua-nginx-module / lua-resty-core pair
+passes cobro's WAF unit tests but kills nginx in the prod config).
+
+CI does both for `x86_64` and `aarch64` on every pull request, so a local build is
+only needed to iterate on the spec. The build needs a host of the target
+architecture — it is a native `rpmbuild`, not a cross-build.
 
 ## Development instructions
 Running `./debug.sh` will build the container and start bash session inside it.
@@ -35,6 +42,17 @@ internal public storage.
   of permissions issues.
 
 ### Upload a new RPM to github releases:
+Push a tag named `<Version>-<Release>` (matching `nginx.spec`) and CI builds both
+architectures, validates them, and attaches them to that release — creating it if
+it does not exist yet:
+
+```bash
+git tag 1.31.2-4 && git push origin 1.31.2-4
+```
+
+To attach an RPM by hand instead — a rebuild of an already-released tag, or an
+architecture CI cannot reach:
+
 ```bash
 grm release surfly/nginx-rpm -f rpms/<rpm-file> -t <version>
 

--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 echo "Building image..."
 podman build -t nginx-build-image -f Containerfile .
 
+mkdir -p rpms
+
 echo "Building rpm..."
 podman run \
     --name nginx-builder \

--- a/build.sh
+++ b/build.sh
@@ -6,8 +6,6 @@ set -euo pipefail
 echo "Building image..."
 podman build -t nginx-build-image -f Containerfile .
 
-mkdir -p rpms
-
 echo "Building rpm..."
 podman run \
     --name nginx-builder \

--- a/debug.sh
+++ b/debug.sh
@@ -15,5 +15,6 @@ podman run \
     -v $PWD/nginx.spec:/root/rpmbuild/SPECS/nginx.spec:Z \
     -v $PWD/nginx.service:/root/rpmbuild/SOURCES/nginx.service:Z \
     -v $PWD/nginx.logrotate:/root/rpmbuild/SOURCES/nginx.logrotate:Z \
-    localhost/nginx-build-image:latest \
+    -v $PWD/nginx.conf:/root/rpmbuild/SOURCES/nginx.conf:Z \
+    localhost/nginx-build-image-debug:latest \
     bash -c "yum-builddep -y /root/rpmbuild/SPECS/nginx.spec && cd /root/rpmbuild/SPECS/ && bash"

--- a/validate.sh
+++ b/validate.sh
@@ -1,14 +1,24 @@
 #!/bin/bash
 
-# Validates a built RPM before it is released: every module is present at the
-# version nginx.spec pins, and resty.core actually loads. The WAF unit tests in
-# cobro use a minimal config that never requires resty.core, so a mismatched
-# lua-nginx-module / lua-resty-core pair passes them and kills nginx in prod.
+# Validates a built RPM before it is released: it was built from the current spec,
+# every module compiled into it matches the version nginx.spec pins, and all five
+# shipped modules load. The WAF unit tests in cobro use a minimal config that never
+# requires resty.core, so a mismatched lua-nginx-module / lua-resty-core pair passes
+# them and kills nginx in prod -- the nginx -t gate below is what catches that.
+#
+# luajit2, lua-resty-core and lua-resty-lrucache are not version-checked: none of
+# them appear in `nginx -V`, luajit reports a rolling build number rather than its
+# tag, and lrucache's own _VERSION lags its release tag upstream.
 
 set -euo pipefail
 
 CALLER_PWD=$PWD
 cd "$(dirname "$(readlink -f "$0")")"
+
+if [[ $# -gt 1 ]]; then
+    echo "usage: $0 [path-to-rpm]   (one at a time)" >&2
+    exit 1
+fi
 
 RPM_PATH="${1:-}"
 if [[ -n "$RPM_PATH" && "$RPM_PATH" != /* ]]; then
@@ -32,10 +42,27 @@ fi
 RPM_DIR=$(cd "$(dirname "$RPM_PATH")" && pwd)
 RPM_FILE=$(basename "$RPM_PATH")
 
-FEDORA_VERSION=$(echo "$RPM_FILE" | grep -oE '\.fc[0-9]+\.' | tr -d '.fc' || true)
+# nginx-lua-waf-<version>-<release>.fc<N>.<arch>.rpm
+if [[ ! "$RPM_FILE" =~ ^nginx-lua-waf-([0-9.]+)-([0-9]+)\.fc([0-9]+)\.[^.]+\.rpm$ ]]; then
+    echo "cannot parse a version, release and Fedora version out of $RPM_FILE" >&2
+    exit 1
+fi
+RPM_VERSION="${BASH_REMATCH[1]}"
+RPM_RELEASE="${BASH_REMATCH[2]}"
+FEDORA_VERSION="${BASH_REMATCH[3]}"
+
 NGINX_VERSION=$(grep -m1 '^Version:' nginx.spec | awk '{print $2}' || true)
-if [[ -z "$FEDORA_VERSION" || -z "$NGINX_VERSION" ]]; then
-    echo "cannot read the Fedora version from $RPM_FILE or Version: from nginx.spec" >&2
+SPEC_RELEASE=$(grep -m1 '^Release:' nginx.spec | awk '{print $2}' || true)
+SPEC_RELEASE=${SPEC_RELEASE%%\%*}
+if [[ -z "$NGINX_VERSION" || -z "$SPEC_RELEASE" ]]; then
+    echo "cannot read Version: or Release: from nginx.spec" >&2
+    exit 1
+fi
+
+# One stale RPM in rpms/ passes every other check here, since the expected module
+# versions come from the same spec that would have built it.
+if [[ "$RPM_VERSION-$RPM_RELEASE" != "$NGINX_VERSION-$SPEC_RELEASE" ]]; then
+    echo "$RPM_FILE is $RPM_VERSION-$RPM_RELEASE, nginx.spec says $NGINX_VERSION-$SPEC_RELEASE" >&2
     exit 1
 fi
 
@@ -83,7 +110,7 @@ nginx -V 2>&1 | tee /tmp/nginx-V
 
 missing=0
 for want in $EXPECTED; do
-    if grep -qF "$want" /tmp/nginx-V; then
+    if grep -qE "${want//./\\.}([^0-9.]|\$)" /tmp/nginx-V; then
         echo "ok      $want"
     else
         echo "MISSING $want"

--- a/validate.sh
+++ b/validate.sh
@@ -40,11 +40,14 @@ EXPECTED=(
 
 echo "Validating $RPM_FILE against fedora:$FEDORA_VERSION"
 
-podman run --rm \
+LOG=$(mktemp)
+trap 'rm -f "$LOG"' EXIT
+
+podman run --rm -i \
     -v "$RPM_DIR":/rpms:Z \
     -e RPM_FILE="$RPM_FILE" \
     -e EXPECTED="${EXPECTED[*]}" \
-    "quay.io/fedora/fedora:$FEDORA_VERSION" bash -s <<'CONTAINER'
+    "quay.io/fedora/fedora:$FEDORA_VERSION" bash -s <<'CONTAINER' | tee "$LOG"
 set -euo pipefail
 
 dnf install -y "/rpms/$RPM_FILE" > /dev/null
@@ -80,6 +83,12 @@ CONF
 
 echo "--- resty.core gate ---"
 nginx -t
+
+echo VALIDATED
 CONTAINER
+
+# Drop the -i above and the container's bash reads EOF, runs nothing and exits 0,
+# so the sentinel is what proves the checks ran -- not the exit code.
+grep -qx VALIDATED "$LOG"
 
 echo "OK: $RPM_FILE"

--- a/validate.sh
+++ b/validate.sh
@@ -7,36 +7,62 @@
 
 set -euo pipefail
 
+CALLER_PWD=$PWD
+cd "$(dirname "$(readlink -f "$0")")"
+
 RPM_PATH="${1:-}"
-if [[ -z "$RPM_PATH" ]]; then
-    RPM_PATH=$(ls -1 rpms/*.rpm 2>/dev/null | head -n1 || true)
+if [[ -n "$RPM_PATH" && "$RPM_PATH" != /* ]]; then
+    RPM_PATH="$CALLER_PWD/$RPM_PATH"
 fi
-if [[ -z "$RPM_PATH" || ! -f "$RPM_PATH" ]]; then
-    echo "usage: $0 <path-to-rpm>   (default: the first file in rpms/)" >&2
+if [[ -z "$RPM_PATH" ]]; then
+    # rpms/ is gitignored and accumulates, so refuse to guess between builds.
+    shopt -s nullglob
+    found=(rpms/*.rpm)
+    if [[ ${#found[@]} -ne 1 ]]; then
+        echo "found ${#found[@]} RPMs in rpms/, pass the one to validate" >&2
+        exit 1
+    fi
+    RPM_PATH="${found[0]}"
+fi
+if [[ ! -f "$RPM_PATH" ]]; then
+    echo "usage: $0 <path-to-rpm>" >&2
     exit 1
 fi
 
 RPM_DIR=$(cd "$(dirname "$RPM_PATH")" && pwd)
 RPM_FILE=$(basename "$RPM_PATH")
 
-spec_global() {
-    grep -m1 "^%global $1 " nginx.spec | awk '{print $3}'
-}
-
-FEDORA_VERSION=$(echo "$RPM_FILE" | grep -oE '\.fc[0-9]+\.' | tr -d '.fc')
-NGINX_VERSION=$(grep -m1 '^Version:' nginx.spec | awk '{print $2}')
+FEDORA_VERSION=$(echo "$RPM_FILE" | grep -oE '\.fc[0-9]+\.' | tr -d '.fc' || true)
+NGINX_VERSION=$(grep -m1 '^Version:' nginx.spec | awk '{print $2}' || true)
+if [[ -z "$FEDORA_VERSION" || -z "$NGINX_VERSION" ]]; then
+    echo "cannot read the Fedora version from $RPM_FILE or Version: from nginx.spec" >&2
+    exit 1
+fi
 
 # The configure args embed each module's source directory, so its pinned version
-# shows up in `nginx -V` output verbatim.
-EXPECTED=(
-    "nginx/$NGINX_VERSION"
-    "lua-nginx-module-$(spec_global lua_nginx_module_version)"
-    "ngx_devel_kit-$(spec_global ngx_devel_kit_version)"
-    "ngx_http_redis-$(spec_global ngx_http_redis_version)"
-    "headers-more-nginx-module-$(spec_global headers_more_version)"
-    "ModSecurity-nginx-$(spec_global modsecurity_nginx_version)"
-    "njs-$(spec_global njs_version)"
+# shows up in `nginx -V` output verbatim. Left of the colon is what appears there,
+# right of it is the nginx.spec key holding the version.
+MODULES=(
+    "lua-nginx-module:lua_nginx_module_version"
+    "ngx_devel_kit:ngx_devel_kit_version"
+    "ngx_http_redis:ngx_http_redis_version"
+    "headers-more-nginx-module:headers_more_version"
+    "ModSecurity-nginx:modsecurity_nginx_version"
+    "njs:njs_version"
 )
+
+EXPECTED=("nginx/$NGINX_VERSION")
+for entry in "${MODULES[@]}"; do
+    key=${entry##*:}
+    version=$(grep -m1 -E "^%global ${key}[[:space:]]" nginx.spec | awk '{print $3}' || true)
+    # An empty version would leave a bare "name-" prefix, which grep -F matches in
+    # any nginx -V output -- the gate would pass on every build.
+    if [[ -z "$version" ]]; then
+        echo "nginx.spec has no %global $key" >&2
+        exit 1
+    fi
+    EXPECTED+=("${entry%%:*}-$version")
+done
 
 echo "Validating $RPM_FILE against fedora:$FEDORA_VERSION"
 
@@ -69,10 +95,15 @@ if [[ $missing -ne 0 ]]; then
     exit 1
 fi
 
+# nginx -V only proves what ./configure was told, so load every shipped module to
+# prove the .so files themselves are usable against this nginx.
 moduledir="$(rpm --eval %{_libdir})/nginx/modules"
 cat > /etc/nginx/nginx.conf <<CONF
 load_module "$moduledir/ndk_http_module.so";
 load_module "$moduledir/ngx_http_lua_module.so";
+load_module "$moduledir/ngx_stream_module.so";
+load_module "$moduledir/ngx_http_js_module.so";
+load_module "$moduledir/ngx_stream_js_module.so";
 events {}
 http {
     lua_package_path "/usr/local/lib/lua/?.lua;;";

--- a/validate.sh
+++ b/validate.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Validates a built RPM before it is released: every module is present at the
+# version nginx.spec pins, and resty.core actually loads. The WAF unit tests in
+# cobro use a minimal config that never requires resty.core, so a mismatched
+# lua-nginx-module / lua-resty-core pair passes them and kills nginx in prod.
+
+set -euo pipefail
+
+RPM_PATH="${1:-}"
+if [[ -z "$RPM_PATH" ]]; then
+    RPM_PATH=$(ls -1 rpms/*.rpm 2>/dev/null | head -n1 || true)
+fi
+if [[ -z "$RPM_PATH" || ! -f "$RPM_PATH" ]]; then
+    echo "usage: $0 <path-to-rpm>   (default: the first file in rpms/)" >&2
+    exit 1
+fi
+
+RPM_DIR=$(cd "$(dirname "$RPM_PATH")" && pwd)
+RPM_FILE=$(basename "$RPM_PATH")
+
+spec_global() {
+    grep -m1 "^%global $1 " nginx.spec | awk '{print $3}'
+}
+
+FEDORA_VERSION=$(echo "$RPM_FILE" | grep -oE '\.fc[0-9]+\.' | tr -d '.fc')
+NGINX_VERSION=$(grep -m1 '^Version:' nginx.spec | awk '{print $2}')
+
+# The configure args embed each module's source directory, so its pinned version
+# shows up in `nginx -V` output verbatim.
+EXPECTED=(
+    "nginx/$NGINX_VERSION"
+    "lua-nginx-module-$(spec_global lua_nginx_module_version)"
+    "ngx_devel_kit-$(spec_global ngx_devel_kit_version)"
+    "ngx_http_redis-$(spec_global ngx_http_redis_version)"
+    "headers-more-nginx-module-$(spec_global headers_more_version)"
+    "ModSecurity-nginx-$(spec_global modsecurity_nginx_version)"
+    "njs-$(spec_global njs_version)"
+)
+
+echo "Validating $RPM_FILE against fedora:$FEDORA_VERSION"
+
+podman run --rm \
+    -v "$RPM_DIR":/rpms:Z \
+    -e RPM_FILE="$RPM_FILE" \
+    -e EXPECTED="${EXPECTED[*]}" \
+    "quay.io/fedora/fedora:$FEDORA_VERSION" bash -s <<'CONTAINER'
+set -euo pipefail
+
+dnf install -y "/rpms/$RPM_FILE" > /dev/null
+
+echo "--- nginx -V ---"
+nginx -V 2>&1 | tee /tmp/nginx-V
+
+missing=0
+for want in $EXPECTED; do
+    if grep -qF "$want" /tmp/nginx-V; then
+        echo "ok      $want"
+    else
+        echo "MISSING $want"
+        missing=1
+    fi
+done
+if [[ $missing -ne 0 ]]; then
+    echo "nginx -V does not match the versions pinned in nginx.spec" >&2
+    exit 1
+fi
+
+moduledir="$(rpm --eval %{_libdir})/nginx/modules"
+cat > /etc/nginx/nginx.conf <<CONF
+load_module "$moduledir/ndk_http_module.so";
+load_module "$moduledir/ngx_http_lua_module.so";
+events {}
+http {
+    lua_package_path "/usr/local/lib/lua/?.lua;;";
+    init_by_lua_block { require "resty.core" }
+    server { listen 8080; }
+}
+CONF
+
+echo "--- resty.core gate ---"
+nginx -t
+CONTAINER
+
+echo "OK: $RPM_FILE"


### PR DESCRIPTION
Related https://github.com/surfly/it/issues/7856

This adds a workflow that builds it on every PR for both architectures — `ubuntu-24.04` and `ubuntu-24.04-arm`, both free hosted runners since the repo is public, so no arm64 hardware is needed — and on a tag push attaches both RPMs to that release. Publishing the first one therefore needs a `Release:` bump, since the tag has to be new and CI rejects a tag that disagrees with the spec; the manual `grm release` path stays documented for attaching an RPM to a tag that already exists.
